### PR TITLE
Fix curl problems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: docker:git
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run: docker build -t docker-concretedeploy .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,31 @@
 FROM docker:stable-git
 
-ENV CURL_VERSION 7.56.1
+# Install curl/nodejs/npm/yarn + dependencies
+RUN apk add --no-cache --update \
+    bash \
+    c-ares-dev \
+    openssl \
+    openssl-dev \
+    ca-certificatesbinutils-gold \
+    curl-dev \
+    curl \
+    autoconf \
+    g++ \
+    gcc \
+    gnupg \
+    libgcc \
+    linux-headers \
+    make \
+    python \
+    nodejs \
+    nodejs-npm \
+    yarn \
+    && rm -r /var/cache/apk \
+    && rm -r /usr/share/man
 
-RUN apk add --no-cache --update bash c-ares-dev openssl openssl-dev ca-certificates
-RUN apk add --no-cache --update --virtual .curl-deps g++ make perl && \
-    wget https://curl.haxx.se/download/curl-$CURL_VERSION.tar.bz2 && \
-    tar xjvf curl-$CURL_VERSION.tar.bz2 && \
-    rm curl-$CURL_VERSION.tar.bz2 && \
-    cd curl-$CURL_VERSION && \
-    ./configure \
-      --build=$CBUILD \
-      --host=$CHOST \
-      --prefix=/usr \
-      --enable-ipv6 \
-      --enable-unix-sockets \
-      --without-libidn \
-      --without-libidn2 \
-      --disable-ldap \
-      --with-pic \
-      --enable-ares \
-    make && \
-    make install && \
-    cd / && \
-    rm -r curl-$CURL_VERSION && \
-    rm -r /var/cache/apk && \
-    rm -r /usr/share/man
-    
 RUN curl "https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get" | bash
 RUN helm init --client-only && \
-      helm plugin install "https://github.com/hypnoglow/helm-s3.git" && \
-      apk del .curl-deps
+    helm plugin install "https://github.com/hypnoglow/helm-s3.git"
 
 RUN apk --no-cache add --virtual .awscli-deps py2-pip py-setuptools && \
     apk --no-cache add groff less python2 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM docker:stable-git
 
 # Install curl/nodejs/npm/yarn + dependencies
-RUN apk add --no-cache --update \
+RUN apk update && \
+    apk add --no-cache --update \
     bash \
     c-ares-dev \
     openssl \
     openssl-dev \
-    ca-certificatesbinutils-gold \
+    ca-certificates \
+    binutils-gold \
     curl-dev \
     curl \
     autoconf \


### PR DESCRIPTION
Switched to using the standard alpine install method for curl.
Added some more deps for nodejs builds.
Added circleci config so we have some checks in github.